### PR TITLE
fix window creation changing X video mode

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,7 +47,8 @@ int main() {
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4); // OpenGL 4.6
     glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 6);
 
-    window = glfwCreateWindow(640, 480, "engine33", glfwGetPrimaryMonitor(), NULL);
+    const GLFWvidmode* mode = glfwGetVideoMode(glfwGetPrimaryMonitor());
+    window = glfwCreateWindow(mode->width, mode->height, "engine33", glfwGetPrimaryMonitor(), NULL);
 
     glfwWindowHint(GLFW_FLOATING, GLFW_TRUE);
     glfwWindowHint(GLFW_RESIZABLE, GLFW_TRUE);


### PR DESCRIPTION
fixes the window-creation process...currently the window-creation changes the mode of the "glfw primary monitor" ... this really sucks because i dont wanna do xrandr --output eDP-1 --mode 1920x1080 every time i ``make run``. and the window itself sucks too....