### PR TITLE
Fix segmentation fault on nullptr-deref

### DIFF
--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -179,6 +179,11 @@ void Mesh::update_mesh_bufs() {
 void Mesh::render() {
     // Guess what this does!
 
+    if(shader == nullptr) {
+        std::cerr<<"Shader must not be null!"<<std::endl;
+        exit(1);
+    }
+
     glm::mat4 m = model_matrix();
     glm::mat4 v = cam.viewmatrix();
     glm::mat4 p = cam.projectionmatrix();


### PR DESCRIPTION
When a mesh without shader "entry" is specified in the loadfile, "shader" remains NULL and will be dereferenced in mesh.cpp / Mesh::render()